### PR TITLE
path function not exported from Rsamtools

### DIFF
--- a/R/bamUtils.R
+++ b/R/bamUtils.R
@@ -1506,7 +1506,8 @@ varcount = function(bams, gr, min.mapq = 0, min.baseq = 20, max.depth = 500, ind
     }
 
     if (is(bams, 'BamFile') | is(bams, 'BamFileList')){
-        bam.paths = Rsamtools::path(bams)
+        ## xt 6/12, "path" is no longer exported from Rsamtools, use from BiocGenerics
+        bam.paths = BiocGenerics::path(bams)
     } else if (is(bams, 'BamFileList')){
         bam.paths = sapply(bams, path)
     } else if (is(bams, 'list')){

--- a/R/bamUtils.R
+++ b/R/bamUtils.R
@@ -1506,8 +1506,8 @@ varcount = function(bams, gr, min.mapq = 0, min.baseq = 20, max.depth = 500, ind
     }
 
     if (is(bams, 'BamFile') | is(bams, 'BamFileList')){
-        ## xt 6/12, "path" is no longer exported from Rsamtools, use from BiocGenerics
-        bam.paths = BiocGenerics::path(bams)
+        ## xt 6/12, "path" is no longer exported from Rsamtools or BiocGenerics
+        bam.paths = path(bams)
     } else if (is(bams, 'BamFileList')){
         bam.paths = sapply(bams, path)
     } else if (is(bams, 'list')){

--- a/tests/testthat/test_bamUtils_ops.R
+++ b/tests/testthat/test_bamUtils_ops.R
@@ -298,10 +298,10 @@ test_that('varbase', {
 
 
 
-gr2dt(read.bam(example_bam, all=TRUE, intervals = GRanges('1:10075-10100')))
+## gr2dt(read.bam(example_bam, all=TRUE, intervals = GRanges('1:10075-10100')))
 
 
-as.data.frame(gr2dt(read.bam(example_bam, all=TRUE, intervals = GRanges('1:10075-10100'))[[2]]))
+## as.data.frame(gr2dt(read.bam(example_bam, all=TRUE, intervals = GRanges('1:10075-10100'))[[2]]))
 
 
 test_that('splice.cigar', {


### PR DESCRIPTION
in `varcounts` when transforming the BAM file list object back to plain file paths, use `path` instead of `Rsamtools::path` because it is not an exported function of Rsamtools